### PR TITLE
增加全局变量和默认用例支持

### DIFF
--- a/templates/common_section.py
+++ b/templates/common_section.py
@@ -1,6 +1,6 @@
 
 class ObjectDotAccessWrapper:
-    raw = None
+    raw = {}
 
     def __init__(self, _data):
         self._data = _data


### PR DESCRIPTION
在config中，增加variables：全局变量和testcases：默认用例的支持，默认用例用于性能、http状态码等公共断言，减少断言的编写的重复性